### PR TITLE
ci: fail commits if a main function in root

### DIFF
--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "Running pre-commit hooks..."
+
+FILES=$(git diff --cached --name-only --diff-filter=AM)
+
+for FILE in $FILES; do
+	if [[ ! "$FILE" =~ / ]]; then
+		if grep -qP '\s*int\s+main\(.*\)' "$FILE"; then
+			echo COMMIT STOPPED: root level files should not contain \'main\'.
+			echo -e "\t"The file \'"$FILE"\' is at the root level and contains a 'main' function.
+			echo -e "\t"If \'"$FILE"\' is pushed, Holberton\'s build will fail.
+			echo
+			echo pre-commit check failed.
+			exit 1 
+		fi
+	fi
+	echo -e "\tAll checks for 'main' in root passed."
+done
+
+
+echo All pre-commit checks passed.
+exit 0


### PR DESCRIPTION
My understanding is that Holberton's server-side build compiles *.c files that are in the root directory. To create an executable, they supply a file with a 'main' entry point. If our repository also contains a 'main' function, their server-side build will fail.

To prevent us from getting the repository into an illegal state (main functions at the root level), I have written a pre-commit hook. Git uses hook scripts as a method of user customisation. The hook script I have written will scan the staging area for any new or modified files and exit an attempted commit if it finds a main function in any of root level files.

To ensure your local repository is using this (and other) hooks, type the following at the root level of the repository:

	git config core.hooksPath git_hooks

This will direct git to look for a pre-commit CI script in git_hooks instead of in .git/hooks. This is the method git suggests for sharing git hooks with users of a repository.