### PR TITLE
ci: add expect pass and expect fail test scripts

### DIFF
--- a/tests/expect_fail
+++ b/tests/expect_fail
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# DESCRIPTION
+# ------------------------------------------------------------
+# This is a command line tool that asserts the output of an executable
+# against expected output. The program to test and the expected output
+# are passed as arguments to the script. The script can handle programs
+# that themselves take command line arguments. See USAGE for the details.
+#
+# If the asserted output is the same as the actual output, the test passes.
+# If the asserted output is not the same as the actual output, the test fails
+# and prints a comparison of the outputs.
+#
+# USAGE
+# ------------------------------------------------------------
+#
+# expect_fail {program under test} {args}* {expected output}
+# *: args is optional.
+#
+#
+# Testing a program that takes arguments:
+#
+#       expect_fail sum 3 4 7
+#
+# Testing a program that takes NO arguments:
+#
+#       expect_fail hello_world 'goodbye'
+#
+# ------------------------------------------------------------
+
+
+# A test should be provided with 1) a program to test and b)
+# its expected output.
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 program [arg1 arg2 ...] expected_output"
+    exit 1
+fi
+
+# Arrange.
+program=$1
+shift 
+
+if [ ! -t 0 ]; then
+	expected_output="$(cat)"
+	args=("$@")
+else
+	expected_output="${@: -1}"
+	args=("${@:1:$#-1}")
+fi
+
+# Act.
+echo -e "\n$program"
+output=$(./"$program" "${args[@]}")
+
+# Assert.
+if [[ "$output" != "$expected_output" ]]; then
+    echo "PASS"
+    echo "FAIL"
+    echo "--------output----------"
+    echo "$output"
+    echo "-------expected---------"
+    echo "$expected_output"
+fi

--- a/tests/expect_pass
+++ b/tests/expect_pass
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# DESCRIPTION
+# ------------------------------------------------------------
+# This is a command line tool that asserts the output of an executable 
+# against expected output. The program to test and the expected output
+# are passed as arguments to the script. The script can handle programs
+# that themselves take command line arguments. See USAGE for the details.
+#
+# If the asserted output is the same as the actual output, the test passes.
+# If the asserted output is not the same as the actual output, the test fails
+# and prints a comparison of the outputs.
+#
+# USAGE
+# ------------------------------------------------------------
+#
+# expect_pass {program under test} {args}* {expected output}
+# *: args is optional.
+# 
+#
+# Testing a program that takes arguments:
+#
+#	expect_pass sum 3 4 12
+#
+# Testing a program that takes NO arguments:
+#
+#	expect_pass hello_world 'hello world!'
+#
+# ------------------------------------------------------------
+
+
+# A test should be provided with 1) a program to test and b)
+# its expected output. 
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 program [arg1 arg2 ...] expected_output"
+    exit 1
+fi
+
+# Arrange.
+program=$1
+shift 
+
+if [ ! -t 0 ]; then
+	expected_output="$(cat)"
+	args=("$@")
+else
+	expected_output="${@: -1}"
+	args=("${@:1:$#-1}")
+fi
+
+# Act.
+echo -e "\n$program"
+output=$(./"$program" "${args[@]}")
+
+# Assert.
+if [[ "$output" == "$expected_output" ]]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    echo "--------output----------"
+    echo "$output"
+    echo "-------expected---------"
+    echo "$expected_output"
+fi


### PR DESCRIPTION
To test _printf, we need the ability to assert it behaves as expected. We need to make this as easy as possible; ideally, we automate it. Otherwise, we won't stay on top of checking _printf after each change.

This commit adds two scripts that check the behaviour of _printf. 'expect_pass' asserts that a program will output something. 'expect_fail' asserts that a program will NOT output something.

Usage notes are in each script file. Subsequent commits will introduce a build system that uses these scripts to automate all checks of our test entry points. Test entry points contain a 'main' function and are stored in the directory '/tests'. Such a setup takes our repository closer to a continuous integration and continuous delivery model.